### PR TITLE
Use default python_executable when pythonPath is not a filepath

### DIFF
--- a/mypyls/mypy_server.py
+++ b/mypyls/mypy_server.py
@@ -71,7 +71,8 @@ def start_server_and_analyze(config, workspace, python_executable=None):
     options.check_untyped_defs = True
     options.follow_imports = 'error'
     options.use_fine_grained_cache = True
-    options.python_executable = python_executable
+    if python_executable is not None:
+        options.python_executable = python_executable
 
     stderr_stream = StringIO()
     config_file = settings.get('configFile')


### PR DESCRIPTION
I have a python file:
```python
import grpc
```

After installing the dependency via `pip3 install grpcio`, the mypy-vscode extension reports this error
`example.py:1:1: error: Cannot find implementation or library stub for module named 'grpc'`

This happens because:
- By default, VSCode sets "python.pythonPath" to "python"

- `mypy_server.py` fetches this value in `confiuration_changed()`

- `got_python_executable()` decides that this is not a file that can be executed and sets `python_executable` to `None`.

- `start_server_and_analyze()` then sets `options.python_executable` from its default of `sys.executable` to that value.

- Because options.python_executable is `None`, `modulefinder.py` in mypy simply returns `[]` for site-packages: https://github.com/python/mypy/blob/63f2fed5d0e10d4d875442e9bba2283c81dfdf4b/mypy/modulefinder.py#L465

- Thus, mypy cannot find my dependency and returns:
`example.py:1:1: error: Cannot find implementation or library stub for module named 'grpc'`

This commit only overrides the default `options.python_executable` if ours is not `None`. I don't know if this is the _best_ way to solve the problem, but I think leaving `options.python_executable` as its default is a reasonable thing to do.